### PR TITLE
Add raw_id_fields for parent

### DIFF
--- a/navbuilder/admin.py
+++ b/navbuilder/admin.py
@@ -24,6 +24,7 @@ class MenuItemAdmin(admin.ModelAdmin):
     prepopulated_fields = {"slug": ["title"]}
     search_fields = ["title", "slug"]
     list_filter = ["menu"]
+    raw_id_fields = ("parent",)
 
     def _get_absolute_url(self, obj):
         try:

--- a/navbuilder/admin.py
+++ b/navbuilder/admin.py
@@ -20,7 +20,7 @@ class MenuAdmin(admin.ModelAdmin):
 
 class MenuItemAdmin(admin.ModelAdmin):
     form = MenuItemAdminForm
-    list_display = ["title", "parent", "_get_absolute_url"]
+    list_display = ["title", "slug", "parent", "_get_absolute_url"]
     prepopulated_fields = {"slug": ["title"]}
     search_fields = ["title", "slug"]
     list_filter = ["menu"]


### PR DESCRIPTION
@qoda: A selectbox for selecting a parent is no longer useful (too many items and duplicate names), I changed to raw_id_fields which allows them to search for the id also.